### PR TITLE
changed urls of Stripe checkout sessions

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -29,8 +29,8 @@ class BookingsController < ApplicationController
           currency: 'usd',
           quantity: 1
         }],
-          success_url: dashboard_url,
-          cancel_url: dashboard_url
+          success_url: request.base_url + '/dashboard',
+          cancel_url: request.base_url + '/dashboard'
       )
 
       @booking.update(checkout_session_id: session.id)


### PR DESCRIPTION
Redirection to dashboard works now on development. We'd have to check it on production though.