### PR TITLE
updated dashboard view

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,7 +11,7 @@ class PagesController < ApplicationController
   def dashboard
     @user = current_user
     # if current_user.is_photographer
-    #@events = Event.all
+    @events = Event.all
     @bookings = Booking.where(photographer_id: current_user.photographer)
     # add the current_user to find the unique bookings for a photographer's dashboard
     # else

--- a/app/views/shared/_pgr_booked_events.html.erb
+++ b/app/views/shared/_pgr_booked_events.html.erb
@@ -2,10 +2,33 @@
   <div class="event-infos">
     <h5 style="color: grey"><%= event.name %></h5>
     <div class="d-flex" style="justify-content: space-between;">
-    <h5 style="color: grey"><%= event.start_date.strftime("%B %d, %Y") %> </h5>
-    <%= button_to "Cancel", availablephotographer_path(current_user.photographer.availablephotographers.where(event_id: event.id)[0].id), method: :delete, class: "btn btn-primary"  %>
-     </div>
+      <h5 style="color: grey"><%= event.start_date.strftime("%B %d, %Y") %> </h5>
+      <a class="btn btn-primary" data-toggle="modal" data-target="#ManageAvailabilityModal<%= event.id %>" href="#" role="button">You're shooting this event!</a>
+    </div>
       <h2  style="border-bottom: #0fabbc solid;"></h2>
   </div>
+</div>
 
+<div class="modal fade" id= "ManageAvailabilityModal<%= event.id %>" >
+    <div class="modal-dialog modal-dialog-centered " style="max-width: 100%">
+      <div class="modal-content">
+
+        <!-- Modal Header -->
+        <div class="modal-header">
+          <h4 class="modal-title" style="color: grey">Are you sure you want to cancel your availability for <strong><%= event.name %></strong>?</h4>
+          <button type="button" class="close" data-dismiss="modal">&times;</button>
+        </div>
+
+        <!-- Modal body dynamic days as per event-->
+        <div class="modal-body">
+          <%= button_to "Cancel Availability", availablephotographer_path(current_user.photographer.availablephotographers.where(event_id: event.id)[0].id), method: :delete, class: "btn btn-danger"  %>
+        </div>
+
+        <!-- Modal footer -->
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+        </div>
+
+      </div>
+    </div>
 </div>

--- a/app/views/shared/_photographer.html.erb
+++ b/app/views/shared/_photographer.html.erb
@@ -33,9 +33,6 @@
                   <li class="nav-item">
                     <a class="nav-link active" data-toggle="tab" href="#pag2-1" role="tab" aria-controls="My Clients">My Events</a>
                   </li>
-                  <li class="nav-item">
-                  <a class="nav-link" data-toggle="tab" href="#pag2-2" role="tab" aria-controls="Event Manager">Booked Event</a>
-                  </li>
                 </ul>
 
             <div class="tab-content">
@@ -43,28 +40,28 @@
               <div class="tab-pane active" id="pag2-1" role="tabpanel">
                 <div class="sv-tab-panel">
                     <div class=“container2-1”>
-                      <div class=“homepage-cards”>
-                        <% @bookings.each do |booking| %>
-                          <%= render 'shared/photographer_manage_events', event: booking.event %>
-                        <% end %>
+                      <div class="row">
+                        <div class="col-6 col-lg-6 col-md-6 col-sm-6">
+                          <div class=“homepage-cards”>
+                            <% @events.each do |event| %>
+                              <%= render 'shared/photographer_manage_events', event: event %>
+                            <% end %>
+                          </div>
+
+                        </div>
+                        <div class="col-6 col-lg-6 col-md-6 col-sm-6">
+                          <div class=“homepage-cards”>
+                             <%  @eventsregistered.each do |event| %>
+                              <%= render 'shared/pgr_booked_events', event: event %>
+                             <% end %>
+                          </div>
+                        </div>
                       </div>
+
                     </div>
                 </div>
               </div>
 
-              <div class="tab-pane" id="pag2-2" role="tabpanel">
-                <div class="sv-tab-panel">
-                  <div class=“container2-2”>
-
-
-                      <div class=“homepage-cards”>
-                         <%  @eventsregistered.each do |event| %>
-                          <%= render 'shared/pgr_booked_events', event: event %>
-                         <% end %>
-                      </div>
-                  </div>
-                </div>
-              </div>
 
             </div>
           </div>

--- a/app/views/shared/_photographer_manage_events.html.erb
+++ b/app/views/shared/_photographer_manage_events.html.erb
@@ -1,19 +1,19 @@
-<div class="event-show-card mt-4" >
+<% if event.start_date > Date.today && event.availablephotographers.where(photographer_id: current_user.photographer.id)[0].nil? %>
+  <div class="event-show-card mt-4" >
 
-    <div class="event-infos">
-        <div>
-          <h5 style="color: grey"><%= event.name %></h5>
-          <h5 style="color: grey">Dates needed: <%= event.start_date.strftime("%B %d, %Y") %> </h5>
-          <p style="color: grey"><strong>Venue:</strong> Outdoor racetrack</p>
-          <p style="color: grey"><strong>Walking rate:</strong> Heavy</p>
-          <p style="color: grey"><strong>Average consumer spending/day:</strong> $200USD</p>
-        </div>
-         <a class="btn btn-primary" data-toggle="modal" data-target="#ManageEventModal<%= event.id %>" href="#" role="button">Shoot this event</a>
-         <h2  style="border-bottom: #0fabbc solid;"></h2>
-    </div>
-
-
-</div>
+      <div class="event-infos">
+          <div>
+            <h5 style="color: grey"><%= event.name %></h5>
+            <h5 style="color: grey">Dates needed: <%= event.start_date.strftime("%B %d, %Y") %> </h5>
+            <p style="color: grey"><strong>Venue:</strong> Outdoor racetrack</p>
+            <p style="color: grey"><strong>Walking rate:</strong> Heavy</p>
+            <p style="color: grey"><strong>Average consumer spending/day:</strong> $200USD</p>
+          </div>
+            <a class="btn btn-danger" data-toggle="modal" data-target="#ManageEventModal<%= event.id %>" href="#" role="button">Shoot this event</a>
+           <h2  style="border-bottom: #0fabbc solid;"></h2>
+      </div>
+  </div>
+<% end %>
 
 
 <!-- The Modal -->
@@ -46,6 +46,8 @@
       </div>
     </div>
   </div>
+
+
 
 
 


### PR DESCRIPTION
![2020-05-06 (4)](https://user-images.githubusercontent.com/57924455/81144658-1dc54780-8fa7-11ea-8a46-b8de9abfdc18.png)

updated pages controller to show only all events in event management tab events tab not bookings as before. 

added filter to pages controller to only load events for which the start date has not passed

merged booked events tab and events tab **suggested view**

